### PR TITLE
Don't cache entries between plugin executions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ In a babel configuration, add both plugins and set the options
 
 #### Options
 This plugin allows a number of configurations to be passed:
-- `outputFile`: Output PO file (default `strings.po`)
+- `outputFile`: Output PO file name (default is the current file being processed or `strings.po` as a fallback)
+- `outputDir`: Output directory (default is dir of the current file being processed)
 - `includeReference`: Whether to include a file reference for PO entries (default `false`)
-- `baseDir`: Root directory of project. Everything up to and including this will be stripped from entry references.
+- `baseReferenceDir`: Root directory of project. Everything up to and including this will be stripped from entry references.
 - `charset`: Character set for the PO (default `UTF-8`)
 - `headers`: Object indicating all PO headers to include. See the default headers [here](https://github.com/rtymchyk/babel-plugin-extract-text/blob/master/src/builders.js#L24).
 - `component`/`function`: Objects customizing the extraction for component/function respectively. This includes the React component name to look for, the function names, and so on. See the default configuration [here](https://github.com/rtymchyk/babel-plugin-extract-text/blob/master/src/arguments.js).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This plugin allows a number of configurations to be passed:
 ## Example
 Plugin Configuration
 ```javascript
-const babel = require('babel-core');
+const babel = require('babel-core')
 
 babel.transformFile('someCode.js', {
   plugins: [
@@ -56,7 +56,7 @@ babel.transformFile('someCode.js', {
       },
     }],
   ],
-});
+}, (error) => error ? console.log(error) : console.log('Done!'))
 ```
 
 Input (`someCode.js`)
@@ -72,7 +72,7 @@ Input (`someCode.js`)
 // Shortform style, using gettext function directly
 <Message i18n={_('Hello World')} />
 
-_c('Flag', 'Physical Object');
+_c('Flag', 'Physical Object')
  ```
 
 Output (`someCode.js.po`)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This plugin allows a number of configurations to be passed:
 - `outputFile`: Output PO file name (default is the `${currentFileProcessed}.po`)
 - `outputDir`: Output directory (default is dir of the current file being processed)
 - `includeReference`: Whether to include a file reference for PO entries (default `false`)
-  - `baseReferenceDir`: Directory that should be used as a staring point for reference paths
+- `baseReferenceDir`: Directory that should be used as a staring point for reference paths
 - `charset`: Character set for the PO (default `UTF-8`)
 - `headers`: Object indicating all PO headers to include. See the default headers [here](https://github.com/rtymchyk/babel-plugin-extract-text/blob/master/src/builders.js#L24).
 - `component`/`function`: Objects customizing the extraction for component/function respectively. This includes the React component name to look for, the function names, and so on. See the default configuration [here](https://github.com/rtymchyk/babel-plugin-extract-text/blob/master/src/arguments.js).
@@ -42,7 +42,6 @@ babel.transformFile('someCode.js', {
   plugins: [
     'syntax-jsx',
     ['extract-text', {
-      outputFile: 'en-US.po',
       includeReference: true,
       headers: {
         'po-revision-date': new Date().toISOString(),
@@ -76,7 +75,7 @@ Input (`someCode.js`)
 _c('Flag', 'Physical Object');
  ```
 
-Output (`en-US.po`)
+Output (`someCode.js.po`)
 ```
 msgid ""
 msgstr ""

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ In a babel configuration, add both plugins and set the options
 
 #### Options
 This plugin allows a number of configurations to be passed:
-- `outputFile`: Output PO file name (default is the current file being processed or `strings.po` as a fallback)
+- `outputFile`: Output PO file name (default is the `${currentFileProcessed}.po`)
 - `outputDir`: Output directory (default is dir of the current file being processed)
 - `includeReference`: Whether to include a file reference for PO entries (default `false`)
-- `baseReferenceDir`: Root directory of project. Everything up to and including this will be stripped from entry references.
+  - `baseReferenceDir`: Directory that should be used as a staring point for reference paths
 - `charset`: Character set for the PO (default `UTF-8`)
 - `headers`: Object indicating all PO headers to include. See the default headers [here](https://github.com/rtymchyk/babel-plugin-extract-text/blob/master/src/builders.js#L24).
 - `component`/`function`: Objects customizing the extraction for component/function respectively. This includes the React component name to look for, the function names, and so on. See the default configuration [here](https://github.com/rtymchyk/babel-plugin-extract-text/blob/master/src/arguments.js).

--- a/plugin.js
+++ b/plugin.js
@@ -13,24 +13,25 @@ const {
 } = require('./src/builders')
 
 module.exports = ({ types }) => {
-  const entries = []
-
   return {
+    pre (state) {
+      this.entries = []
+    },
     visitor: {
       CallExpression (path, state) {
         const entry = buildCallExpressionEntry(types, path, state)
-        if (entry) entries.push(entry)
+        if (entry) this.entries.push(entry)
       },
       JSXElement (path, state) {
         const entry = buildJSXElementEntry(types, path, state)
-        if (entry) entries.push(entry)
+        if (entry) this.entries.push(entry)
       },
     },
     post (state) {
       const thisPlugin = state.opts.plugins.filter(plugin => plugin[0].key === PLUGIN_KEY)[0]
       const args = thisPlugin[1] || {}
       const outputFile = args.outputFile || DEFAULT_OUTPUT_FILE
-      const poRawData = mergeEntries(args, entries)
+      const poRawData = mergeEntries(args, this.entries)
       const po = gettextParser.po.compile(poRawData)
 
       fs.writeFileSync(outputFile, po)

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 const gettextParser = require('gettext-parser')
 const fs = require('fs')
+const path = require('path')
 
 const PLUGIN_KEY = process.env.NODE_ENV === 'test'
   ? './plugin.js' : 'extract-text'
@@ -28,13 +29,23 @@ module.exports = ({ types }) => {
       },
     },
     post (state) {
+      if (this.entries.length === 0) return
+
       const thisPlugin = state.opts.plugins.filter(plugin => plugin[0].key === PLUGIN_KEY)[0]
       const args = thisPlugin[1] || {}
-      const outputFile = args.outputFile || DEFAULT_OUTPUT_FILE
+
+      const currentFileName = path.basename(this.file.opts.filename)
+      const currentFileDir = path.dirname(this.file.opts.filename)
+
+      const outputFile = args.outputFile ||
+        (currentFileName !== 'unknown' && `${currentFileName}.po`) ||
+        DEFAULT_OUTPUT_FILE
+      const outputDir = args.outputDir || currentFileDir
+
       const poRawData = mergeEntries(args, this.entries)
       const po = gettextParser.po.compile(poRawData)
 
-      fs.writeFileSync(outputFile, po)
+      fs.writeFileSync(path.join(outputDir, outputFile), po)
     },
   }
 }

--- a/src/builders.js
+++ b/src/builders.js
@@ -99,15 +99,15 @@ function mergeTranslation (existingTranslation, newTranslation) {
 function buildReference (entry, state) {
   if (entry && state.opts.includeReference) {
     const rawFilename = state.file.opts.filename
-    const baseDirRaw = state.opts.baseDir
+    const baseReferenceDirRaw = state.opts.baseReferenceDir
 
-    if (baseDirRaw) {
-      const baseDir = `/${baseDirRaw.replace('/', '')}/`
-      const baseDirIndex = rawFilename.indexOf(baseDir)
+    if (baseReferenceDirRaw) {
+      const baseReferenceDir = `/${baseReferenceDirRaw.replace('/', '')}/`
+      const baseReferenceDirIndex = rawFilename.indexOf(baseReferenceDir)
 
-      if (baseDirIndex !== -1) {
+      if (baseReferenceDirIndex !== -1) {
         entry.reference = rawFilename.substr(
-          baseDirIndex + baseDir.length, rawFilename.length)
+          baseReferenceDirIndex + baseReferenceDir.length, rawFilename.length)
         return entry
       }
     }

--- a/test/builders.spec.js
+++ b/test/builders.spec.js
@@ -345,7 +345,7 @@ describe('builders', () => {
         Object.assign({}, state, {
           opts: {
             includeReference: true,
-            baseDir: 'project',
+            baseReferenceDir: 'project',
           },
         }))
 
@@ -359,7 +359,7 @@ describe('builders', () => {
           includeReference: true,
           opts: {
             includeReference: true,
-            baseDir: 'x',
+            baseReferenceDir: 'x',
           },
         }))
 

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -20,7 +20,6 @@ const OPTIONS = {
 
 describe('plugin', () => {
   afterEach(() => {
-    jest.resetModules()
     if (fs.existsSync(TESTPO)) {
       fs.unlinkSync(TESTPO)
     }


### PR DESCRIPTION
The issue is that when the babel plugin module is loaded, it maintains a memoized array of translation entries. As babel traverses different files, it beings to accumulate results from previous files. For example:

Run on file X -> [entryX]
Run on file Y -> [entryX, entryY]
Run on file Z -> [entryX, entryY, entryZ]

The solution is to store entries per plugin execution, not per module load.

**BREAKING CHANGES**
* Introduction of a a new config `outputDir` where extracted POs are placed
* `outputFile` config now has the default of being `{fileBeingProcessed}.po` instead of `strings.po`
* `baseDir` renamed to `baseReferenceDir` for consistency